### PR TITLE
VS organize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.2.2)
 # Project name
 project(vtkmofo LANGUAGES Fortran)
 
+# Turn on the ability to create folders to organize projects (.vcproj)
+# It creates "CMakePredefinedTargets" folder by default and adds CMake
+# defined projects like INSTALL.vcproj and ZERO_CHECK.vcproj
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # System options
 if ( "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
   set(prefix "/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,13 @@ else()
 endif()
 
 
+# Check if using OpenCoarrays caf wrapper
+if(CMAKE_Fortran_COMPILER MATCHES "caf$")
+  set(USING_CAF_COMPILER_WRAPPER TRUE)
+  set(DEFAULT_NUM_IMAGES 1)
+endif()
+
+
 ##################################################
 # Begin VTKmofo specific targets and configuration
 ##################################################
@@ -117,12 +124,20 @@ endforeach()
 
 # Add unit tests and define the string that is used to signal success
 foreach(unit_test ${VTKmofo_unit_test_list})
-  add_test(NAME "${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/)
-  set_property(TEST "${unit_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Test passed")
+  if(USING_CAF_COMPILER_WRAPPER)
+    add_caf_test("VTKmofo_${unit_test}_test" ${DEFAULT_NUM_IMAGES} ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test})
+  else()
+    add_test(NAME "VTKmofo_${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit)
+  endif()
+  set_property(TEST "VTKmofo_${unit_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Test passed")
 endforeach()
 
 # Add integration tests and define the string that is used to signal success
 foreach(integration_test ${VTKmofo_integration_test_list})
-  add_test(NAME "${integration_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/)
-  set_property(TEST "${integration_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Finished")
+  if(USING_CAF_COMPILER_WRAPPER)
+    add_caf_test("VTKmofo_${integration_test}_test" ${DEFAULT_NUM_IMAGES} ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test})
+  else()
+    add_test(NAME "VTKmofo_${integration_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/integration)
+  endif()
+  set_property(TEST "VTKmofo_${integration_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Finished")
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,49 +58,71 @@ else()
   )
 endif()
 
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
-# Specify directories
-set(src
-"src/Precision.f90"
-"src/Misc.f90"
-"src/VTK_attributes.f90"
-"src/VTK_cells.f90"
-"src/VTK_datasets.f90"
-"src/VTK_interface.f90"
-"src/VTK_vars.f90"
-)
+##################################################
+# Begin VTKmofo specific targets and configuration
+##################################################
 
-# Make as a static library
-include_directories(${CMAKE_BINARY_DIR}/mod)
-add_library(vtkmofo ${src})
-install(TARGETS vtkmofo DESTINATION lib)
-install(DIRECTORY "${CMAKE_BINARY_DIR}/mod/" DESTINATION mod)
+# Where to put VTKmofo module files
+set(VTKmofo_mod_dir ${CMAKE_CURRENT_BINARY_DIR}/mod)
 
-#Specify all the subdirectories containing codes that produce executable files or libraries:
-set(subdirectories_list tests/unit tests/integration)
-foreach(subdirectory ${subdirectories_list})
-  add_subdirectory(${subdirectory})
+# Specify VTKmofo sources
+set(VTKmofo_files
+  "Precision.f90"
+  "Misc.f90"
+  "VTK_attributes.f90"
+  "VTK_cells.f90"
+  "VTK_datasets.f90"
+  "VTK_interface.f90"
+  "VTK_vars.f90"
+  )
+foreach(item ${VTKmofo_files})
+  list(APPEND VTKmofo_sources "${CMAKE_CURRENT_SOURCE_DIR}/src/${item}")
 endforeach()
+
+# Make VTKmofo static library
+add_library(vtkmofo STATIC ${VTKmofo_sources})
+
+# Tell CMake where to put vtkmofo .mod files generated with libvtkmofo
+set_property(TARGET vtkmofo
+  PROPERTY
+  Fortran_MODULE_DIRECTORY ${VTKmofo_mod_dir})
+
+# Tell consumers where to find .mod files
+target_include_directories(vtkmofo PUBLIC ${VTKmofo_mod_dir})
+
+# Organize things in Visual Studio
+source_group("VTKmofoLib" FILES ${VTKmofo_sources})
+set_property(TARGET vtkmofo
+  PROPERTY
+  FOLDER "VTKmofo")
+install(TARGETS vtkmofo DESTINATION lib)
+install(DIRECTORY "${VTKmofo_mod_dir}" DESTINATION mod)
+
+
+######################
+# Add test directories
+######################
 
 enable_testing()
 
-# Unit Tests
-set(unit_test_list attributes cells datasets
-                   )
+# Specify all the subdirectories containing test executable/library sources:
+set(subdirectories_list tests/unit tests/integration)
+foreach(subdirectory ${subdirectories_list})
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/${subdirectory}")
+endforeach()
 
-# Integration Tests
-set(integration_test_list cube cylinder rectangular_prism pyramid t_shape
-                          )
+# Unit Tests exported from tests/unit subdirectory in ${VTKmofo_unit_test_list}
+# Integration Tests exported from tests/integration in ${VTKmofo_integration_test_list}
 
 # Add unit tests and define the string that is used to signal success
-foreach(unit_test ${unit_test_list})
-  add_test(NAME "${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test}_unit WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/)
+foreach(unit_test ${VTKmofo_unit_test_list})
+  add_test(NAME "${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/)
   set_property(TEST "${unit_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Test passed")
 endforeach()
 
 # Add integration tests and define the string that is used to signal success
-foreach(integration_test ${integration_test_list})
+foreach(integration_test ${VTKmofo_integration_test_list})
   add_test(NAME "${integration_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/)
   set_property(TEST "${integration_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Finished")
 endforeach()

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,22 +1,22 @@
-# Integration tests
-include_directories(${CMAKE_BINARY_DIR}/mod)
+function(add_VTKmofo_integration_test test_name)
+  # Assumes source file is ${test_name}.f90
+  add_executable(${test_name} ${test_name}.f90)
+  target_link_libraries(${test_name} vtkmofo)
+  set_property(TARGET ${test_name}
+    PROPERTY
+    FOLDER "VTKmofo-Integration-Tests")
+  source_group("VTKmofo\\IntegrationTests" FILES ${test_name}.f90)
+endfunction(add_VTKmofo_integration_test)
 
-# Cube geometry
-add_executable(cube Cube.f90)
-target_link_libraries(cube vtkmofo)
+foreach(test
+    Cube
+    Cylinder
+    Rectangular_prism
+    Pyramid
+    T_shape)
+  add_VTKmofo_integration_test(${test})
+  list(APPEND VTKmofo_integration_test_list "${test}")
+endforeach()
 
-# Cylindrical geometry
-add_executable(cylinder Cylinder.f90)
-target_link_libraries(cylinder vtkmofo)
-
-# Rectangular prism geometry
-add_executable(rectangular_prism Rectangular_prism.f90)
-target_link_libraries(rectangular_prism vtkmofo)
-
-# Pyramid geometry
-add_executable(pyramid Pyramid.f90)
-target_link_libraries(pyramid vtkmofo)
-
-# T_shape geometry
-add_executable(t_shape T_shape.f90)
-target_link_libraries(t_shape vtkmofo)
+# Export integration test list so that we don't have to keep track if it twice
+set(VTKmofo_integration_test_list "${VTKmofo_integration_test_list}" PARENT_SCOPE)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Unit tests
-include_directories(${CMAKE_BINARY_DIR}/mod)
+include_directories("${VTKmofo_mod_dir}")
 
 # Add object library to work around CMake parallel build w/ module quirk
 add_library(VTKmofoPassFail OBJECT VTKmofoAnalyze.f90)
 
-function(add_VTKmofo_test test_name)
+function(add_VTKmofo_unit_test test_name)
   # Assumes source file is ${test_name}.f90
   add_executable(${test_name} ${test_name}.f90 $<TARGET_OBJECTS:VTKmofoPassFail>)
   target_link_libraries(${test_name} vtkmofo)
@@ -12,13 +12,15 @@ function(add_VTKmofo_test test_name)
     PROPERTY
     FOLDER "VTKmofo-Unit-Tests")
   source_group("VTKmofo\\UnitTests" FILES ${test_name}.f90)
-endfunction(add_VTKmofo_test)
+endfunction(add_VTKmofo_unit_test)
 
-# attributes
-add_VTKmofo_test(attributes_unit)
+foreach(test
+    attributes_unit
+    cells_unit
+    datasets_unit)
+  add_VTKmofo_unit_test(${test})
+  list(APPEND VTKmofo_unit_test_list ${test})
+endforeach()
 
-# cells
-add_VTKmofo_test(cells_unit)
-
-# datasets
-add_VTKmofo_test(datasets_unit)
+# Set the VTKmofo_unit_test_list in parent scope
+set(VTKmofo_unit_test_list ${VTKmofo_unit_test_list} PARENT_SCOPE)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,14 +4,21 @@ include_directories(${CMAKE_BINARY_DIR}/mod)
 # Add object library to work around CMake parallel build w/ module quirk
 add_library(VTKmofoPassFail OBJECT VTKmofoAnalyze.f90)
 
+function(add_VTKmofo_test test_name)
+  # Assumes source file is ${test_name}.f90
+  add_executable(${test_name} ${test_name}.f90 $<TARGET_OBJECTS:VTKmofoPassFail>)
+  target_link_libraries(${test_name} vtkmofo)
+  set_property(TARGET ${test_name}
+    PROPERTY
+    FOLDER "VTKmofo-Unit-Tests")
+  source_group("VTKmofo\\UnitTests" FILES ${test_name}.f90)
+endfunction(add_VTKmofo_test)
+
 # attributes
-add_executable(attributes_unit attributes_unit.f90 $<TARGET_OBJECTS:VTKmofoPassFail>)
-target_link_libraries(attributes_unit vtkmofo)
+add_VTKmofo_test(attributes_unit)
 
 # cells
-add_executable(cells_unit cells_unit.f90 $<TARGET_OBJECTS:VTKmofoPassFail>)
-target_link_libraries(cells_unit vtkmofo)
+add_VTKmofo_test(cells_unit)
 
 # datasets
-add_executable(datasets_unit datasets_unit.f90 $<TARGET_OBJECTS:VTKmofoPassFail>)
-target_link_libraries(datasets_unit vtkmofo)
+add_VTKmofo_test(datasets_unit)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -3,6 +3,9 @@ include_directories("${VTKmofo_mod_dir}")
 
 # Add object library to work around CMake parallel build w/ module quirk
 add_library(VTKmofoPassFail OBJECT VTKmofoAnalyze.f90)
+set_property(TARGET VTKmofoPassFail
+  PROPERTY
+  FOLDER "VTKmofo-Unit-Tests")
 
 function(add_VTKmofo_unit_test test_name)
   # Assumes source file is ${test_name}.f90
@@ -11,7 +14,7 @@ function(add_VTKmofo_unit_test test_name)
   set_property(TARGET ${test_name}
     PROPERTY
     FOLDER "VTKmofo-Unit-Tests")
-  source_group("VTKmofo\\UnitTests" FILES ${test_name}.f90)
+  source_group("VTKmofo\\UnitTests" FILES ${test_name}.f90 VTKmofoAnalyze.f90)
 endfunction(add_VTKmofo_unit_test)
 
 foreach(test


### PR DESCRIPTION
Group into folders in Visual Studio and support/fix tests when built with `caf` wrapper script as part of parent projects. Currently, compiling directly with `caf` on it's own will still fail, it is assumed that the `caf_add_test` macro is defined by the parent project.

In the long run, we should switch to a `find_package(opencoarrays)` approach, but, for now, this is the best approach.

@porteri This should be ready to merge; tested extensively on *nix.