### PR TITLE
Add labels for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,12 +90,12 @@ set(integration_test_list cube cylinder rectangular_prism pyramid t_shape
 
 # Add unit tests and define the string that is used to signal success
 foreach(unit_test ${unit_test_list})
-  add_test(NAME "${unit_test}_test" COMMAND ${CMAKE_BINARY_DIR}/tests/unit/${unit_test}_unit WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/unit/)
+  add_test(NAME "${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test}_unit WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/)
   set_property(TEST "${unit_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Test passed")
 endforeach()
 
 # Add integration tests and define the string that is used to signal success
 foreach(integration_test ${integration_test_list})
-  add_test(NAME "${integration_test}_test" COMMAND ${CMAKE_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/integration/)
+  add_test(NAME "${integration_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/)
   set_property(TEST "${integration_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Finished")
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ foreach(unit_test ${VTKmofo_unit_test_list})
     add_test(NAME "VTKmofo_${unit_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unit/${unit_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/unit)
   endif()
   set_property(TEST "VTKmofo_${unit_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Test passed")
+  set_property(TEST "VTKmofo_${unit_test}_test" PROPERTY LABELS "VTKmofo" "unit-test")
 endforeach()
 
 # Add integration tests and define the string that is used to signal success
@@ -140,4 +141,10 @@ foreach(integration_test ${VTKmofo_integration_test_list})
     add_test(NAME "VTKmofo_${integration_test}_test" COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/${integration_test} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/integration)
   endif()
   set_property(TEST "VTKmofo_${integration_test}_test" PROPERTY PASS_REGULAR_EXPRESSION "Finished")
+  set_property(TEST "VTKmofo_${integration_test}_test" PROPERTY LABELS "VTKmofo" "integration-test")
 endforeach()
+
+add_custom_target(RUN_ALL_VTKmofo_TESTS
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -L "VTKmofo")
+add_dependencies(RUN_ALL_VTKmofo_TESTS ${VTKmofo_unit_test_list} ${VTKmofo_integration_test_list})
+set_property(TARGET RUN_ALL_VTKmofo_TESTS PROPERTY FOLDER "All-Tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,5 +146,4 @@ endforeach()
 
 add_custom_target(RUN_ALL_VTKmofo_TESTS
   COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --output-on-failure -L "VTKmofo")
-add_dependencies(RUN_ALL_VTKmofo_TESTS ${VTKmofo_unit_test_list} ${VTKmofo_integration_test_list})
 set_property(TARGET RUN_ALL_VTKmofo_TESTS PROPERTY FOLDER "All-Tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,6 @@ foreach(integration_test ${VTKmofo_integration_test_list})
 endforeach()
 
 add_custom_target(RUN_ALL_VTKmofo_TESTS
-  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -L "VTKmofo")
+  COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --output-on-failure -L "VTKmofo")
 add_dependencies(RUN_ALL_VTKmofo_TESTS ${VTKmofo_unit_test_list} ${VTKmofo_integration_test_list})
 set_property(TARGET RUN_ALL_VTKmofo_TESTS PROPERTY FOLDER "All-Tests")


### PR DESCRIPTION
 - Will allow targets for grouping them by label
 - Add target for all VTKmofo tests

 - N.B. target names like RUN_UNIT_TESTS may clash with parent
   projects, so only top level project should declare them unless
   super builds etc. are used