### PR TITLE
Update appveyor to use Ubuntu 18 w/ gfortran8.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,11 @@ platform:
 # Need to add ssh_keys for submodules to work on windows
 # howto article: https://www.appveyor.com/docs/how-to/private-git-sub-modules/
 for:
--
+  -
   matrix:
     only:
       - image: Ubuntu1604
-       - install:
+      install:
           - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
           - sh: sudo apt-get -yq update > /dev/null
           - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,32 +13,18 @@ platform:
 
 # Need to add ssh_keys for submodules to work on windows
 # howto article: https://www.appveyor.com/docs/how-to/private-git-sub-modules/
-for:
-  -
-  matrix:
-    only:
-      - image: Ubuntu1604
-      install:
-          - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
-          - sh: sudo apt-get -yq update > /dev/null
-          - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null
-          - sh: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-8
-          - sh: sudo update-alternatives --auto gcc
-          - sh: sudo update-alternatives --display gcc
-          - sh: export FC=gfortran
-          - sh: export CC=gcc
-          - sh: $FC --version
-          - sh: $CC --version
-          - sh: cmake --version
-
-      - image: Ubuntu1804
-      install:
-          - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
-          - sh: export FC=gfortran
-          - sh: export CC=gcc
-          - sh: $FC --version
-          - sh: $CC --version
-          - sh: cmake --version
+install:
+  - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
+  - sh: sudo apt-get -yq update > /dev/null
+  - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null
+  - sh: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-8
+  - sh: sudo update-alternatives --auto gcc
+  - sh: sudo update-alternatives --display gcc
+  - sh: export FC=gfortran
+  - sh: export CC=gcc
+  - sh: $FC --version
+  - sh: $CC --version
+  - sh: cmake --version
 
 build: off
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ for:
   matrix:
     only:
       - image: Ubuntu1604
-        install:
+      install:
           - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
           - sh: sudo apt-get -yq update > /dev/null
           - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null
@@ -32,16 +32,13 @@ for:
           - sh: cmake --version
 
       - image: Ubuntu1804
-        install:
+      install:
           - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
           - sh: export FC=gfortran
           - sh: export CC=gcc
           - sh: $FC --version
           - sh: $CC --version
           - sh: cmake --version
-
-install:
-
 
 build: off
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.0.{build}
 image:
-  - ubuntu
+  - Ubuntu1604
+  - Ubuntu1804
   # - Visual Studio 2017
 stack: python 3
 clone_depth: 30
@@ -12,18 +13,35 @@ platform:
 
 # Need to add ssh_keys for submodules to work on windows
 # howto article: https://www.appveyor.com/docs/how-to/private-git-sub-modules/
+for:
+-
+  matrix:
+    only:
+      - image: Ubuntu1604
+        install:
+          - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
+          - sh: sudo apt-get -yq update > /dev/null
+          - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null
+          - sh: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-8
+          - sh: sudo update-alternatives --auto gcc
+          - sh: sudo update-alternatives --display gcc
+          - sh: export FC=gfortran
+          - sh: export CC=gcc
+          - sh: $FC --version
+          - sh: $CC --version
+          - sh: cmake --version
+
+      - image: Ubuntu1804
+        install:
+          - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
+          - sh: export FC=gfortran
+          - sh: export CC=gcc
+          - sh: $FC --version
+          - sh: $CC --version
+          - sh: cmake --version
+
 install:
-  - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
-  - sh: sudo apt-get -yq update > /dev/null
-  - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null
-  - sh: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-8
-  - sh: sudo update-alternatives --auto gcc
-  - sh: sudo update-alternatives --display gcc
-  - sh: export FC=gfortran
-  - sh: export CC=gcc
-  - sh: $FC --version
-  - sh: $CC --version
-  - sh: cmake --version
+
 
 build: off
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ for:
   matrix:
     only:
       - image: Ubuntu1604
-      install:
+       - install:
           - sh: sudo -E apt-add-repository ppa:ubuntu-toolchain-r/test -y
           - sh: sudo apt-get -yq update > /dev/null
           - sh: sudo apt-get -yq install gcc-8 gfortran-8 > /dev/null


### PR DESCRIPTION
Update Appveyor to use Ubuntu 18 w/ gfortran8.2