### PR TITLE
Travis ci mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
       dist: trusty
       env: GCC=9
       before_install:
-        - sudo apt update
-        - sudo apt install cmake
+        - sudo apt-get update
+        - sudo apt-get install cmake
         - ls /usr/bin/
         - export FC=gfortran-${GCC}
         - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,13 @@ matrix:
       dist: trusty
       env: GCC=8
       before_install:
+        - sudo apt-get purge cmake
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update -q
         - sudo apt autoremove
-        - cmake --version
         - sudo apt-get install cmake3 -y
         - export FC=gfortran-${GCC}
         - cmake --version
-        - cmake3 --version
     - os: osx
       osx_image: xcode10
       env: GCC=8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       before_install:
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update
+        - sudo apt-get install cmake3
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: linux
@@ -14,7 +15,8 @@ matrix:
       env: GCC=8
       before_install:
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
-        - sudo apt-get update
+        - sudo apt-get update -q
+        - sudo apt-get install cmake-3.13.4
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+              key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
           packages:
             - gfortran-7
             - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env:
-        global: GCC=7
+      env: GCC=7
       before_install:
-          - export FC=gfortran-${GCC}
+        - export FC=gfortran-${GCC}
     - os: osx
       osx_image: xcode10
-      env:
-        global: GCC=8.3
+      env: GCC=8.3
       before_install:
         - brew install gcc@8
         - export FC=gfortran-${GCC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ matrix:
       env: GCC=7
       before_install:
         - export FC=gfortran-${GCC}
+    - os: linux
+      dist: trusty
+      env: GCC=8
+      before_install:
+        - export FC=gfortran-${GCC}
     - os: osx
       osx_image: xcode10
       env: GCC=8
       before_install:
         - brew install gcc@8
         - export FC=gfortran-${GCC}
+        - cmake --version
 sudo: false
 addons:
   apt:
@@ -19,6 +25,7 @@ addons:
       - ubuntu-toolchain-r-test
       - dluxen-cmake-backports
     packages:
+      - gfortran-7
       - gfortran-8
       - cmake-data
       - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - GCC=7
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc@8
+  - if [ $TRAVIS_OS_NAME = osx ] brew install gcc@8
   - export FC=gfortran-${GCC}
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ matrix:
       dist: trusty
       env: GCC=9
       before_install:
-        - sudo apt-get update
-        - sudo apt-get install cmake
+        - curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o cmake-3.13.4-Linux-x86_64.tar.gz
+        - tar xf cmake-3.13.4-Linux-x86_64.tar.gz
+        - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - ls /usr/bin/
         - export FC=gfortran-${GCC}
         - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
         - export FC=gfortran-${GCC}
     - os: osx
       osx_image: xcode10
-      env: GCC=8.3
+      env: GCC=8
       before_install:
         - brew install gcc@8
         - export FC=gfortran-${GCC}
@@ -17,9 +17,9 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - george-edison55-precise-backports
+      - dluxen-cmake-backports
     packages:
-      - gfortran-7
+      - gfortran-8
       - cmake-data
       - cmake
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ addons:
     packages:
       - gfortran-7
       - gfortran-8
-      - cmake3-data
-      - cmake3
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
-              key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
           packages:
             - gfortran-7
-            - cmake
     - os: linux
       dist: trusty
       env: GCC=8
@@ -54,6 +51,7 @@ matrix:
       env: GCC=8
       before_install:
         - brew install gcc@8
+        - brew install cmake
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx
@@ -61,6 +59,7 @@ matrix:
       env: GCC=9
       before_install:
         - brew install gcc@9
+        - brew install cmake
         - export FC=gfortran-${GCC}
         - cmake --version
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ matrix:
         - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - export FC=gfortran-${GCC}
         - cmake --version
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran-7
     - os: linux
       dist: trusty
       env: GCC=8
@@ -19,6 +25,12 @@ matrix:
         - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - export FC=gfortran-${GCC}
         - cmake --version
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran-8
     - os: linux
       dist: trusty
       env: GCC=9
@@ -28,6 +40,12 @@ matrix:
         - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - export FC=gfortran-${GCC}
         - cmake --version
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran-9
     - os: osx
       osx_image: xcode10
       env: GCC=8
@@ -43,14 +61,6 @@ matrix:
         - export FC=gfortran-${GCC}
         - cmake --version
 sudo: false
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gfortran-7
-      - gfortran-8
-      - gfortran-9
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       dist: trusty
       env: GCC=8
       before_install:
-        - sudo apt-get purge cmake
+        - sudo update-alternatives --remove-all cmake
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update -q
         - sudo apt autoremove

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gfortran-7
+            - cmake
     - os: linux
       dist: trusty
       env: GCC=8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,15 @@ matrix:
         - sudo update-alternatives --set cmake usr/bin/cmake-3.14.4
         - export FC=gfortran-${GCC}
         - cmake --version
+    - os: linux
+      dist: trusty
+      env: GCC=9
+      before_install:
+        - sudo apt update -q
+        - sudo apt install cmake
+        - ls /usr/bin/
+        - export FC=gfortran-${GCC}
+        - cmake --version
     - os: osx
       osx_image: xcode10
       env: GCC=8

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
     packages:
       - gfortran-7
       - gfortran-8
-      - cmake-data
+      - cmake3-data
       - cmake3
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
       before_install:
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update
+        - sudo apt autoremove
+        - cmake --version
+        - sudo apt-get install cmake3-data
         - sudo apt-get install cmake3
         - export FC=gfortran-${GCC}
         - cmake --version
@@ -16,7 +19,9 @@ matrix:
       before_install:
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update -q
-        - sudo apt-get install cmake-3.13.4
+        - sudo apt autoremove
+        - cmake --version
+        - sudo apt-get install cmake3
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ matrix:
       env: GCC=7
       before_install:
         - export FC=gfortran-${GCC}
+        - cmake --version
     - os: linux
       dist: trusty
       env: GCC=8
       before_install:
         - export FC=gfortran-${GCC}
+        - cmake --version
     - os: osx
       osx_image: xcode10
       env: GCC=8
@@ -30,7 +32,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - dluxen-cmake-backports
+      - ppa:dluxen/cmake-backports
     packages:
       - gfortran-7
       - gfortran-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       dist: trusty
       env: GCC=7
       before_install:
-        - sudo add-apt-repository ppa:dluxen/cmake-backports
+        - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update
         - export FC=gfortran-${GCC}
         - cmake --version
@@ -13,8 +13,8 @@ matrix:
       dist: trusty
       env: GCC=8
       before_install:
-        - add-apt-repository ppa:dluxen/cmake-backports
-        - apt-get update
+        - sudo add-apt-repository ppa:dluxen/cmake-backports -y
+        - sudo apt-get update
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx
@@ -36,7 +36,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - ppa:dluxen/cmake-backports
     packages:
       - gfortran-7
       - gfortran-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: generic
-os: linux
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: osx
+      osx_image: xcode10
 sudo: false
-dist: trusty
 addons:
   apt:
     sources:
@@ -13,9 +17,11 @@ addons:
       - cmake
 env:
   global:
+    - if [ $TRAVIS_OS_NAME = linux ]; then GCC=7; else GCC=8; fi
     - GCC=7
 
 before_install:
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc@8
   - export FC=gfortran-${GCC}
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ matrix:
         - brew install gcc@8
         - export FC=gfortran-${GCC}
         - cmake --version
+    - os: osx
+      osx_image: xcode10
+      env: GCC=9
+      before_install:
+        - brew install gcc@9
+        - export FC=gfortran-${GCC}
+        - cmake --version
 sudo: false
 addons:
   apt:
@@ -28,7 +35,7 @@ addons:
       - gfortran-7
       - gfortran-8
       - cmake-data
-      - cmake
+      - cmake3
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
         - sudo apt-get install cmake3 -y
         - export FC=gfortran-${GCC}
         - cmake --version
+        - cmake3 --version
     - os: osx
       osx_image: xcode10
       env: GCC=8

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
         - sudo apt-get update -q
         - sudo apt autoremove
         - sudo apt-get install cmake3 -y
+        - ls /usr/bin/
         - sudo update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake-3.14.4 10
         - sudo update-alternatives --set cmake usr/bin/cmake-3.14.4
         - export FC=gfortran-${GCC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,18 @@ matrix:
       dist: trusty
       env: GCC=7
       before_install:
-        - sudo add-apt-repository ppa:dluxen/cmake-backports -y
-        - sudo apt-get update
-        - sudo apt autoremove
-        - cmake --version
-        - sudo apt-get install cmake3 -y
+        - curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o cmake-3.13.4-Linux-x86_64.tar.gz
+        - tar xf cmake-3.13.4-Linux-x86_64.tar.gz
+        - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: linux
       dist: trusty
       env: GCC=8
       before_install:
-        - sudo add-apt-repository ppa:dluxen/cmake-backports -y
-        - sudo apt-get update -q
-        - sudo apt autoremove
-        - sudo apt-get install cmake3 -y
-        - ls /usr/bin/
-        - sudo update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake-3.14.4 10
-        - sudo update-alternatives --set cmake usr/bin/cmake-3.14.4
+        - curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o cmake-3.13.4-Linux-x86_64.tar.gz
+        - tar xf cmake-3.13.4-Linux-x86_64.tar.gz
+        - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: linux
@@ -32,7 +26,6 @@ matrix:
         - curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o cmake-3.13.4-Linux-x86_64.tar.gz
         - tar xf cmake-3.13.4-Linux-x86_64.tar.gz
         - export PATH=${PWD}/cmake-3.13.4-Linux-x86_64/bin:${PATH}
-        - ls /usr/bin/
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx
@@ -57,6 +50,7 @@ addons:
     packages:
       - gfortran-7
       - gfortran-8
+      - gfortran-9
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ matrix:
       dist: trusty
       env: GCC=8
       before_install:
-        - sudo update-alternatives --remove-all cmake
         - sudo add-apt-repository ppa:dluxen/cmake-backports -y
         - sudo apt-get update -q
         - sudo apt autoremove
         - sudo apt-get install cmake3 -y
+        - sudo update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake-3.14.4 10
+        - sudo update-alternatives --set cmake usr/bin/cmake-3.14.4
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       dist: trusty
       env: GCC=9
       before_install:
-        - sudo apt update -q
+        - sudo apt update
         - sudo apt install cmake
         - ls /usr/bin/
         - export FC=gfortran-${GCC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,17 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      env:
+        global: GCC=7
+      before_install:
+          - export FC=gfortran-${GCC}
     - os: osx
       osx_image: xcode10
+      env:
+        global: GCC=8.3
+      before_install:
+        - brew install gcc@8
+        - export FC=gfortran-${GCC}
 sudo: false
 addons:
   apt:
@@ -15,14 +24,6 @@ addons:
       - gfortran-7
       - cmake-data
       - cmake
-env:
-  global:
-    - if [ $TRAVIS_OS_NAME = linux ]; then GCC=7; else GCC=8; fi
-    - GCC=7
-
-before_install:
-  - if [ $TRAVIS_OS_NAME = osx ] brew install gcc@8
-  - export FC=gfortran-${GCC}
 script:
   - mkdir build && cd build && cmake ../ && make -j $(nproc) && ctest -j $(nproc)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ matrix:
       dist: trusty
       env: GCC=7
       before_install:
+        - sudo add-apt-repository ppa:dluxen/cmake-backports
+        - sudo apt-get update
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: linux
       dist: trusty
       env: GCC=8
       before_install:
+        - add-apt-repository ppa:dluxen/cmake-backports
+        - apt-get update
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       env: GCC=8
       before_install:
         - brew install gcc@8
-        - brew install cmake
+        - brew upgrade cmake
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx
@@ -59,7 +59,7 @@ matrix:
       env: GCC=9
       before_install:
         - brew install gcc@9
-        - brew install cmake
+        - brew upgrade cmake
         - export FC=gfortran-${GCC}
         - cmake --version
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ matrix:
         - sudo apt-get update
         - sudo apt autoremove
         - cmake --version
-        - sudo apt-get install cmake3-data
-        - sudo apt-get install cmake3
+        - sudo apt-get install cmake3 -y
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: linux
@@ -21,7 +20,7 @@ matrix:
         - sudo apt-get update -q
         - sudo apt autoremove
         - cmake --version
-        - sudo apt-get install cmake3
+        - sudo apt-get install cmake3 -y
         - export FC=gfortran-${GCC}
         - cmake --version
     - os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMAKE minimum version
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.13.4)
 
 option(VTKmofo_USE_OpenCoarrays
   "Build VTKmofo with support for linking against OpenCoarray programs" OFF)
@@ -9,7 +9,7 @@ project(vtkmofo LANGUAGES Fortran)
 
 # vtkmofo project version
 set (VTKMOFO_VERSION_MAJOR 1)
-set (VTKMOFO_VERSION_MINOR 0)
+set (VTKMOFO_VERSION_MINOR 001)
 
 # Print project logo, version and tag line
 file(READ ${CMAKE_CURRENT_LIST_DIR}/cmake/VTKMOFO-logo.txt VTKMOFO_LOGO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMAKE minimum version
-cmake_minimum_required(VERSION 3.12.2)
+cmake_minimum_required(VERSION 3.13.4)
 
 option(VTKmofo_USE_OpenCoarrays
   "Build VTKmofo with support for linking against OpenCoarray programs" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMAKE minimum version
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.12.2)
 
 option(VTKmofo_USE_OpenCoarrays
   "Build VTKmofo with support for linking against OpenCoarray programs" OFF)

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ This is a generic modern Fortran interface to write a .vtk file using the legacy
 This code is built and tested with the following:
 
 Compilers: (may work for older ones as well)
- - [gfortran][gcc link] 8.2, 8.3, 9.0
+ - [gfortran][gcc link] 7.4, 8.1, 8.2, 8.3, 9.0
  - [Intel][Intel link] 2018
 
 Operating Systems:
- - Linnux (Tested on Ubuntu 18)
+ - Linnux (Tested on Ubuntu 16, 18)
  - Windows (Tested on Windows 8, 10)
  - MacOS
 
 Build System:
- - [CMake][CMake link] 3.9 or newer
+ - [CMake][CMake link] 3.13.4 or newer
 
 Examples:
 # 2D example

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Operating Systems:
  - MacOS
 
 Build System:
- - [CMake][CMake link] 3.13.4 or newer
+ - [CMake][CMake link] 3.12.2 or newer
 
 Examples:
 # 2D example


### PR DESCRIPTION
Fixes #41 
Updates to `travis-ci` to do the following:
* Added MacOS image support
* Added support for compilers for `gfortran-7,8 & 9`
* Updated to `cmake-3.14.4`