### PR TITLE
Fix windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This code is built and tested with the following:
 Compilers: (may work for older ones as well)
  - [gfortran][gcc link] 7.4, 8.1, 8.2, 8.3, 9.0
  - [Intel][Intel link] 2018
+   - * Warning: Intel 2018 does not support derived type IO *
 
 Operating Systems:
  - Linnux (Tested on Ubuntu 16, 18)

--- a/src/utilities/file_utility.f90
+++ b/src/utilities/file_utility.f90
@@ -18,7 +18,7 @@ MODULE File_utility
         CHARACTER(LEN=:), ALLOCATABLE :: form
         CHARACTER(LEN=:), ALLOCATABLE :: access
     CONTAINS
-        PROCEDURE, PRIVATE :: setup_file_information
+        PROCEDURE, PUBLIC  :: setup_file_information
         GENERIC,   PUBLIC  :: setup => setup_file_information
         PROCEDURE, PRIVATE :: check_if_exists
         GENERIC,   PUBLIC  :: exists => check_if_exists

--- a/src/utilities/file_utility_procedures.f90
+++ b/src/utilities/file_utility_procedures.f90
@@ -129,7 +129,7 @@ SUBMODULE (file_utility) file_utility_implementation
         IF (me%unit < 0) THEN
             me%unit = 0 !! Re-set this to a non-negative number for a gfortran-8.3 bug w/ newunit
         END IF
-write(0,*) me%form
+
         OPEN (newunit=me%unit, file=me%filename, iostat=inputstat, Status='REPLACE', Form=me%form, access=me%access)
 
         END PROCEDURE make_file

--- a/src/utilities/xml_procedures.f90
+++ b/src/utilities/xml_procedures.f90
@@ -399,15 +399,22 @@ SUBMODULE (XML) XML_implementation
             CASE ('unformatted')
                 ALLOCATE(me%form, source='UNFORMATTED')  !! Ignore the user-defined form, even if present
                 file_format = binary
+            CASE DEFAULT
+                ERROR STOP 'Error: Unknown value for form. Terminated in XML_file_setup'
             END SELECT
         ELSE
             SELECT CASE (file_format)
             CASE (ascii)
                 ALLOCATE(me%form, source='FORMATTED')
+                file_format = ascii
             CASE (binary)
                 ALLOCATE(me%form, source='UNFORMATTED')
+                file_format = binary
+            CASE DEFAULT
+                ERROR STOP 'Error: Unknown value for file_format. Terminated in XML_file_setup'
             END SELECT
         END IF
+
         file_format_text = convert_format_to_string (file_format)
 !        ALLOCATE(me%access, source='SEQUENTIAL') !! Ignore the user-defined access, even if present
         ALLOCATE(me%access, source='STREAM') !! Ignore the user-defined access, even if present

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,7 +17,6 @@ endfunction(add_VTKmofo_integration_test)
 # legacy tests
 foreach(test
     Append
-    DTIO_T_shape
     Polygonal_data
     Rectilinear_grid
     Structured_grid
@@ -26,6 +25,14 @@ foreach(test
   add_VTKmofo_integration_test(${test} "legacy")
   list(APPEND VTKmofo_integration_test_list "legacy_${test}")
 endforeach()
+
+# Currently ignore the DTIO test b/c Intel 18.x does not properly support DTIO
+if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
+
+else()
+    add_VTK_mofo_integration_test(DTIO_T_shape "legacy")
+    list(APPEND VTKmofo_integration_test_list "legacy_DTIO_T_shape")
+endif()
 
 # serial modern tests
 foreach(test

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach()
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
 
 else()
-    add_VTK_mofo_integration_test(DTIO_T_shape "legacy")
+    add_VTKmofo_integration_test(DTIO_T_shape "legacy")
     list(APPEND VTKmofo_integration_test_list "legacy_DTIO_T_shape")
 endif()
 

--- a/tests/integration/serial/Rectilinear_grid.f90
+++ b/tests/integration/serial/Rectilinear_grid.f90
@@ -49,10 +49,11 @@ PROGRAM modern_Rectilinear_test
         CALL vals_to_write(i)%attribute%init (dataname(i), numcomp=1, real1d=vals(:,i))
     END DO
 
+    !! ASCII file
     CALL vtk_serial_write (cube, pointdatasets=vals_to_write, unit=unit, filename=filename, title=title)
                                                            !! This tests a full 1-time write
     CLOSE(unit)
-write(0,*) 'rectilinear_grid, before vtk_serial_write for binary'
+
     !! Binary file
     CALL vtk_serial_write (cube, unit=unit, filename='binary_cube_append_' // filename, title=title, format=binary)
 
@@ -62,8 +63,8 @@ write(0,*) 'rectilinear_grid, before vtk_serial_write for binary'
 
     CALL vtk_serial_write (finished=.TRUE.)
     CLOSE(unit)
-write(0,*) 'rectilinear_grid, before vtk_serial_write for ascii'
-    !! Ascii file
+
+    !! ASCII file
     CALL vtk_serial_write (cube, unit=unit, filename='ascii_cube_append_' // filename, title=title, format=ascii)
 
     CALL vtk_serial_write (pointdata=vals_to_write(1)%attribute)

--- a/tests/unit/datasets_unit.f90
+++ b/tests/unit/datasets_unit.f90
@@ -309,7 +309,6 @@ MODULE vtk_datasets_unit_tests
         LOGICAL, DIMENSION(n_types) :: individual_tests_pass
 
         DO i = 1, n_types
-        write(0,*) i
             IF (ALLOCATED(vtk_dataset_1)) DEALLOCATE (vtk_dataset_1)
             IF (ALLOCATED(vtk_dataset_2)) DEALLOCATE (vtk_dataset_2)
             SELECT CASE (i)


### PR DESCRIPTION
Fixes two issues found when running w/ Intel 18 & Windows:
1) Intel 18 can't handle derived type IO. That test case was removed when using Intel compiler and a node was added to the README file.
2) Intel couldn't override a non-public TBP (not sure why gfortran was able to do this) so it was made public.