### PR TITLE
Work around GFortran optimization bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
 elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   set(gnu_compiler true)
   # Fortran 2008 standard, free format (due to automatic build to .f file for testing)
-  set(CMAKE_Fortran_FLAGS "${prefix}std=f2008 ${prefix}fcheck=all ${prefix}Wall ${prefix}Wno-unused-dummy-argument ${prefix}ffree-form")
+  set(CMAKE_Fortran_FLAGS "${prefix}std=f2008 ${prefix}fcheck=all ${prefix}Wall ${prefix}Wno-unused-dummy-argument ${prefix}ffree-form -fbacktrace")
 else()
   message(WARNING
     "\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,20 @@ if(VTKmofo_USE_OpenCoarrays)
     PRIVATE OpenCoarrays::caf_mpi_static)
 endif()
 
+# Work around for GFortran bug
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+  set_property( SOURCE
+    src/utilities/xml_procedures.f90
+    src/modern/VTK_piece_element_procedures.f90
+    src/legacy/VTK_cells_procedures.f90
+    src/legacy/VTK_datasets_procedures.f90
+    APPEND
+    PROPERTY
+    COMPILE_OPTIONS "-O0"
+    )
+endif()
+
+
 # Tell CMake where to put vtkmofo .mod files generated with libvtkmofo
 set_property(TARGET vtkmofo
   PROPERTY


### PR DESCRIPTION
I suspect there is still a *legitimate* issue in your linked list test/structure. If you think this isn't right let me know and I can try to resolve the issue.

```
5: Test command: /Users/ibeekman/Sandbox/vtkmofo/build/tests/unit/linked_list_unit
5: Test timeout computed to be: 10000000
5:
5: Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
5:
5: Backtrace for this error:
5: #0  0x10dccbafd
5: #1  0x10dccae93
5: #2  0x7fff5abb5b5c
 5/17 Test  #5: VTKmofo_linked_list_unit_test ...........***Exception: SegFault  0.01 sec

Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
#0  0x10dccbafd
#1  0x10dccae93
#2  0x7fff5abb5b5c

...

94% tests passed, 1 tests failed out of 17

Label Time Summary:
VTKmofo             =   0.22 sec*proc (17 tests)
integration-test    =   0.15 sec*proc (11 tests)
unit-test           =   0.07 sec*proc (6 tests)

Total Test time (real) =   0.24 sec

The following tests FAILED:
          5 - VTKmofo_linked_list_unit_test (SEGFAULT)
```