### PR TITLE
cmake updates

### DIFF
--- a/cmake/modules/Platform_Compiler_Options.cmake
+++ b/cmake/modules/Platform_Compiler_Options.cmake
@@ -20,6 +20,9 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     set(colon_ ":")
     set(libs_static "/libs:static")
     set(dbglibs "/dbglibs")
+    set(mp "/MP")
+    set(optimization_0 "/Od")
+    set(fpe_0 "/fpe:0")
   else() # *nix options
     set(prefix "-")
     set(infix " ")
@@ -30,15 +33,24 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     set(colon_ " ")
     set(libs_static "")
     set(dbglibs "")
+    set(mp "-multiple-processes")
+    set(optimization_0 "")
+    set(fpe0 "-fpe0")
   endif()
 
-  set(Intel_Fortran_FLAGS_Release "${prefix}check${colon_}none ${prefix}O3 ${prefix}fpp ${prefix}MP")
-  set(Intel_Fortran_FLAGS_Debug "${prefix}check${colon_}all ${prefix}Od ${prefix}fpp ${prefix}MP ${prefix}warn${colon_}all ${prefix}stand${colon_}f15 ${prefix}fpe${colon_}0")
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 18.0)
+    set(Fortran_standard "f15")
+  else()
+    set(Fortran_standard "f18")
+  endif()
+
+  set(Intel_Fortran_FLAGS_Release "${prefix}check${colon_}none ${prefix}O3 ${prefix}fpp ${mp}")
+  set(Intel_Fortran_FLAGS_Debug "${prefix}check${colon_}all ${optimization_0} ${prefix}fpp ${mp} ${prefix}warn${colon_}all ${fpe} ${prefix}stand${colon_}${Fortran_standard}")
 
 #  "${prefix}nologo ${prefix}debug${infix}full ${prefix}MP ${prefix}Od ${prefix}standard-semantics ${prefix}warn${infix}errors ${prefix}stand${infix}f15 ${prefix}debug-parameters${infix}all ${prefix}warn${infix}unused ${prefix}warn${infix}interfaces ${prefix}${Qf}trapuv ${prefix}${Q}init${eq}snan ${prefix}${Q}init${eq}arrays ${prefix}fpe${colon}0 ${prefix}traceback ${prefix}check${colon_}bounds ${prefix}check${colon_}stack ${libs_static} ${prefix}threads ${dbglibs} ${prefix}free"
 #  "${prefix}nologo ${prefix}debug${infix}full ${prefix}multiple-processes ${prefix}O0 ${prefix}standard-semantics ${prefix}warn${infix}errors ${prefix}stand${infix}f15 ${prefix}debug-parameters${infix}all ${prefix}warn${infix}declarations ${prefix}warn${infix}unused ${prefix}warn${infix}interfaces ${prefix}${Qf}trapuv ${prefix}${Q}init${eq}snan ${prefix}${Q}init${eq}arrays ${prefix}fpe${colon}0 ${prefix}traceback ${prefix}check${colon_}bounds ${prefix}check${colon_}stack ${libs_static} ${prefix}threads ${dbglibs} ${prefix}free"
 
-  set(Intel_EXE_LINKER_FLAGS "${prefix}traceback ${prefix}stand${colon_}f15 ${prefix}${Q}coarray${colon_}distributed ${prefix}fpp")
+set(Intel_EXE_LINKER_FLAGS "${prefix}traceback ${prefix}stand${colon_}{Fortran_standard} ${prefix}${Q}coarray${colon_}distributed ${prefix}fpp")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   # GFortran build configs
   if (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 8)
@@ -46,8 +58,8 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   else()
     set(Fortran_standard "f2018")
   endif()
-  set(GNU_Fortran_FLAGS_Release "-fbacktrace -std=${Fortran_standard} -ffree-form -fcheck=all")
-  set(GNU_Fortran_FLAGS_Debug "-fbacktrace -std=${Fortran_standard} -ffree-form")
+  set(GNU_Fortran_FLAGS_Release "-fbacktrace -std=${Fortran_standard} -ffree-form -fcoarray=single")
+  set(GNU_Fortran_FLAGS_Debug "-fbacktrace -std=${Fortran_standard} -ffree-form -fcoarray=single -fcheck=all -fbounds-check")
 else()
   message(WARNING
     "\n"


### PR DESCRIPTION
cmake fixes:
1) Update for Intel compiler to properly set /f15 or /f18 standard depending on version of ifort
2) Fix for compiler options for linux ifort